### PR TITLE
Add support to mysql tests and deprecate old Django versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ lib/
 db.sqlite
 django_system_globals.egg-info/
 .tox/
+.env

--- a/system_globals_project/settings.py
+++ b/system_globals_project/settings.py
@@ -12,7 +12,7 @@ MANAGERS = ADMINS
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+        'ENGINE': 'django.db.backends.sqlite3',  # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
         'NAME': 'db.sqlite',                      # Or path to database file if using sqlite3.
         'USER': '',                      # Not used with sqlite3.
         'PASSWORD': '',                  # Not used with sqlite3.

--- a/system_globals_project/settings_mysql.py
+++ b/system_globals_project/settings_mysql.py
@@ -1,0 +1,15 @@
+import os
+
+from settings import *  # noqa
+
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'django_systems_global',
+        'USER': os.environ.get('DB_USERNAME', 'root'),
+        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
+        'HOST': os.environ.get('DB_HOST', '127.0.0.1'),
+        'PORT': os.environ.get('DB_PORT', 3306),
+    }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,26 @@
 [tox]
-envlist = py27-django{14,15,16,17,18}
+envlist = py27-django{17,18,19}-{mysql,sqlite}
 
 [testenv]
 env:
     PYTHONWARNINGS=default
 commands =
     python system_globals_project/manage.py test system_globals
-
 deps:
-   django14: Django>=1.4,<1.5
-   django15: Django>=1.5,<=1.6
-   django16: Django>=1.6,<1.7
    django17: Django>=1.7,<1.8
    django18: Django>=1.8,<1.9
+   django19: Django>=1.9,<1.10
+   mysql: MySQL-python==1.2.5
+passenv: DB_USERNAME DB_PASSWORD DB_PORT DB_HOST
+
+[testenv:py27-django17-mysql]
+setenv =
+    DJANGO_SETTINGS_MODULE=settings_mysql
+
+[testenv:py27-django18-mysql]
+setenv =
+    DJANGO_SETTINGS_MODULE=settings_mysql
+
+[testenv:py27-django19-mysql]
+setenv =
+    DJANGO_SETTINGS_MODULE=settings_mysql


### PR DESCRIPTION
- add support running tests with mysql via tox
- deprecate old versions of Django